### PR TITLE
fix(ci): not detecting unused parameter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -261,6 +261,7 @@ linters-settings:
     - name: unreachable-code
     - name: useless-break
     - name: waitgroup-by-value
+    - name: unused-parameter
     severity: error
 
   rowserrcheck:


### PR DESCRIPTION
unused parameter check is disabled by default in revive default config itself